### PR TITLE
Fix API base URL config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5001/api

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A aplicação estará disponível em `http://localhost:5173`.
 Crie um `.env` baseado no [`.env.example`](./.env.example):
 
 ```env
-VITE_API_URL=https://localhost:5001
+VITE_API_URL=http://localhost:5001/api
 ```
 
 ## 🐳 Docker

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 
-const API_URL = "http://18.215.124.246/api"; 
+// Permite configurar a URL da API via variável de ambiente.
+const API_URL =
+  import.meta.env.VITE_API_URL ?? "http://18.215.124.246/api";
 
 export async function login(email, password) {
   try {


### PR DESCRIPTION
## Summary
- allow configuring AuthService API base URL via `VITE_API_URL`
- document env var and provide `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2662ab108329ab12066ea1bc6748