### PR TITLE
Add Login component test with Vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -27,6 +28,11 @@
     "globals": "^16.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.3.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^24.0.0"
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import Login from '../features/login/Login';
+import * as AuthService from '../services/AuthService';
+
+vi.mock('../services/AuthService');
+
+describe('Login', () => {
+  it('submits credentials and navigates to /home', async () => {
+    const loginMock = AuthService.login.mockResolvedValue({});
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/home" element={<div>Home Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/email/i), 'test@example.com');
+    await userEvent.type(screen.getByPlaceholderText(/senha/i), 'password');
+    await userEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    expect(loginMock).toHaveBeenCalledWith('test@example.com', 'password');
+    expect(screen.getByText('Home Page')).toBeInTheDocument();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './setupTests.js',
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment and testing-library
- add setupTests for RTL matchers
- create Login component test covering navigation and service call

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8027bc6883298081527917e55e33